### PR TITLE
Dev => Master with Cors-Anywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "eyes": "^0.1.8",
     "mongodb": "^2.2.22",
     "request": "^2.79.0",
-    "yelp": "^1.0.2"
+    "yelp": "^1.0.2",
+    "cors-anywhere": "^0.4.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -18,3 +18,23 @@ Built by NSC AD, powered by Node and Apache
 * Properties
 * Concerts
 * Food
+
+##Installation & Run
+1. Install mongodb:
+  * Mac OS X: https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/
+  * Windows: https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/
+
+2. Install Node.js and NPM:
+  * https://nodejs.org/en/
+
+3. Clone this repo and get to the root directory via command line (i.e.):
+
+   		`cd ad440-knowseattle`
+
+4. Install necessary Node dependencies:
+
+   		`npm install`
+
+4. Run the server:
+
+   		`node server.js`

--- a/server.js
+++ b/server.js
@@ -4,8 +4,19 @@ var express = require('express');
 var app = express();
 var mainRouter = require('./routers');
 var config = require('./serverConfig');
+// cors-anywhere integration
+var cors_proxy = require('cors-anywhere');
+var cors_host = process.env.PORT ? '0.0.0.0' : '127.0.0.1';
+var cors_port = 9999;
 
 app.use('/', mainRouter);
 app.listen(config.port, config.ip);
-
 console.log('Server running at http://' + config.ip + ':' + config.port);
+
+cors_proxy.createServer({
+    originWhitelist: [], // Allow all origins
+    requireHeader: ['origin', 'x-requested-with'],
+    removeHeaders: ['cookie', 'cookie2']
+}).listen(cors_port, cors_host, function() {
+    console.log('Running CORS Anywhere on ' + cors_host + ':' + cors_port);
+});

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ var config = require('./serverConfig');
 // cors-anywhere integration
 var cors_proxy = require('cors-anywhere');
 var cors_host = process.env.PORT ? '0.0.0.0' : '127.0.0.1';
-var cors_port = 9999;
+var cors_port = 1111;
 
 app.use('/', mainRouter);
 app.listen(config.port, config.ip);

--- a/webroot/js/pages/jobs.js
+++ b/webroot/js/pages/jobs.js
@@ -33,7 +33,7 @@ var avg_company_rating;
 var industry_popularity = new Map();
 
 // CORS bypass
-var cors_api_url = 'https://cors.knowseattle.com/';
+var cors_api_url = 'http://cors.knowseattle.com/';
 
 function getJobsDefault() {
    return "<li>Full-time Jobs: ???</li><li>Avg Company: ???</li>";

--- a/webroot/js/pages/jobs.js
+++ b/webroot/js/pages/jobs.js
@@ -33,7 +33,7 @@ var avg_company_rating;
 var industry_popularity = new Map();
 
 // CORS bypass
-var cors_api_url = 'https://cors-anywhere.herokuapp.com/';
+var cors_api_url = 'http://localhost:9999/';
 
 function getJobsDefault() {
    return "<li>Full-time Jobs: ???</li><li>Avg Company: ???</li>";

--- a/webroot/js/pages/jobs.js
+++ b/webroot/js/pages/jobs.js
@@ -33,7 +33,7 @@ var avg_company_rating;
 var industry_popularity = new Map();
 
 // CORS bypass
-var cors_api_url = 'http://localhost:9999/';
+var cors_api_url = 'https://cors.knowseattle.com/';
 
 function getJobsDefault() {
    return "<li>Full-time Jobs: ???</li><li>Avg Company: ???</li>";


### PR DESCRIPTION
Let's get some cors-anywhere action.

I added the cors-anywhere dependency to package.json, and now it's listening on port 1111.
Requests from client can run through cors.knowseattle.com and they should be able to hack their way through any cross-origin constraint an API can throw at you.

Because security.

@tekbot 