### PR TITLE
Changed cors-anywhere URL 

### DIFF
--- a/webroot/js/pages/jobs.js
+++ b/webroot/js/pages/jobs.js
@@ -33,7 +33,7 @@ var avg_company_rating;
 var industry_popularity = new Map();
 
 // CORS bypass
-var cors_api_url = 'http://cors.knowseattle.com/';
+var cors_api_url = 'https://knowseattle.com/cors/';
 
 function getJobsDefault() {
    return "<li>Full-time Jobs: ???</li><li>Avg Company: ???</li>";


### PR DESCRIPTION
because we don't want to get another SSL cert, and nixing the DNS addition is easier.
new cors-anywhere URL:

'https://knowseattle.com/cors/<insert_API_request_here>'

Because life is always better with 2 reverse proxies.

@tekbot